### PR TITLE
Fix dtype error during quantized generation

### DIFF
--- a/torchtune/modules/attention.py
+++ b/torchtune/modules/attention.py
@@ -211,7 +211,7 @@ class MultiHeadAttention(nn.Module):
         s_y = y.shape[1]
 
         if self.kv_cache and input_pos is None:
-            cache_size = self.kv_cache.size
+            cache_size = self.kv_cache.k_cache.dim(2)
             input_pos = torch.arange(cache_size, cache_size + s_y, device=x.device)
 
         # q has shape [b, s_x, num_heads * head_dim]
@@ -264,6 +264,7 @@ class MultiHeadAttention(nn.Module):
         # Update key-value cache
         if self.kv_cache is not None:
             k, v = self.kv_cache.update(input_pos, k, v)
+            q = q.to(self.kv_cache.dtype)
 
         # shape: [b, 1, s, s]
         if mask is not None:

--- a/torchtune/modules/kv_cache.py
+++ b/torchtune/modules/kv_cache.py
@@ -40,8 +40,8 @@ class KVCache(nn.Module):
         self.register_buffer(
             "v_cache", torch.zeros(cache_shape, dtype=dtype), persistent=False
         )
-        self.size = 0
         self.batch_size = batch_size
+        self.dtype = dtype
 
     def reset(self) -> None:
         """Reset the cache to zero."""
@@ -64,11 +64,10 @@ class KVCache(nn.Module):
             Tuple[Tensor, Tensor]: Updated KV cache with key first
         """
         assert input_pos.shape[0] == k_val.shape[2]
-        self.size = input_pos.max().item() + 1
 
         k_out = self.k_cache
         v_out = self.v_cache
-        k_out[:, :, input_pos] = k_val
-        v_out[:, :, input_pos] = v_val
+        k_out[:, :, input_pos] = k_val.to(self.dtype)
+        v_out[:, :, input_pos] = v_val.to(self.dtype)
 
         return k_out, v_out

--- a/torchtune/modules/kv_cache.py
+++ b/torchtune/modules/kv_cache.py
@@ -42,6 +42,7 @@ class KVCache(nn.Module):
         )
         self.batch_size = batch_size
         self.dtype = dtype
+        self.size = torch.tensor(0, dtype=dtype)
 
     def reset(self) -> None:
         """Reset the cache to zero."""
@@ -64,6 +65,8 @@ class KVCache(nn.Module):
             Tuple[Tensor, Tensor]: Updated KV cache with key first
         """
         assert input_pos.shape[0] == k_val.shape[2]
+
+        self.size = input_pos.max()
 
         k_out = self.k_cache
         v_out = self.v_cache

--- a/torchtune/utils/_generation.py
+++ b/torchtune/utils/_generation.py
@@ -159,7 +159,7 @@ def generate(
         tokens = custom_generate_next_token(
             model,
             input_pos=curr_input_pos,
-            x=tokens,
+            x=tokens.clone(),
             temperature=temperature,
             top_k=top_k,
         )


### PR DESCRIPTION
This PR fixes #1349 RuntimeError: Index put requires the source and destination dtypes match, got BFloat16 for the destination and Float for the source

Repro:
See #1349 for repro
Cmd:
```
$tune run generate --config generate_quant.yaml
```
Output:
```
INFO:torchtune.utils.logging:Running InferenceRecipe with resolved config:

checkpointer:
  _component_: torchtune.utils.FullModelTorchTuneCheckpointer
  checkpoint_dir: quantized/
  checkpoint_files:
  - meta_model_0-8da4w.pt
  model_type: LLAMA3
  output_dir: model-output
device: cuda
dtype: bf16
enable_kv_cache: true
max_new_tokens: 300
model:
  _component_: torchtune.models.llama3_1.llama3_1_8b
  max_seq_len: 2048
prompt: 'Amanda: I baked  cookies. Do you want some?\nJerry: Sure \nAmanda: I will
  bring you tomorrow :-)'
quantizer:
  _component_: torchtune.utils.quantization.Int8DynActInt4WeightQuantizer
  groupsize: 256
seed: 1234
temperature: 0.6
tokenizer:
  _component_: torchtune.models.llama3.llama3_tokenizer
  path: /home/mreso/.cache/huggingface/hub/models--meta-llama--Meta-Llama-3.1-8B-Instruct/snapshots/8c22764a7e3675c50d4c7c9a4edb474456022b16/original/tokenizer.model
top_k: 300

DEBUG:torchtune.utils.logging:Setting manual seed to local seed 1234. Local seed is seed + rank = 1234 + 0
linear: layers.0.attn.q_proj, in=4096, out=4096
linear: layers.0.attn.k_proj, in=4096, out=1024
linear: layers.0.attn.v_proj, in=4096, out=1024
linear: layers.0.attn.output_proj, in=4096, out=4096
....
linear: layers.31.mlp.w1, in=4096, out=14336
linear: layers.31.mlp.w2, in=14336, out=4096
linear: layers.31.mlp.w3, in=4096, out=14336
linear: output, in=4096, out=128256
INFO:torchtune.utils.logging:Model is initialized with precision torch.bfloat16.
INFO:torchtune.utils.logging:Starting compilation to improve generation performance ...
INFO:torchtune.utils.logging:Warmup run for quantized model takes: 33.09 sec
INFO:torchtune.utils.logging:Amanda: I baked  cookies. Do you want some?\nJerry: Sure \nAmanda: I will bring you tomorrow :-) \nJerry: What are you talking about? I want them now\nAmanda: I said tomorrow, you can't just eat them all by yourself, that's not fair. (She laughs.) \nJerry: I'm starving\nAmanda: Go ask someone else, I'm not going to be your cookie m
other \nJerry: That's not fair\nAmanda: I know, but it's not my responsibility to feed you all day \nJerry: Fine, I'll just ask someone else. \nAmanda: And don't eat all the cookies, they're for sharing, remember?\nAmanda: I'm going to go, bye \nJerry: Wait, come back, I'll pay you, I'll buy you more cookies\nAmanda: I don't need your money, I don't need your
cookies, I'll just eat them myself, bye \nJerry: You're really mean\nAmanda: I'm not mean, I'm just firm, that's all\nAmanda: I'm going to go, bye \nJerry: Wait, come back, I'll get you an ice cream, you like ice cream, don't you?\nAmanda: No, I don't want your ice cream, I don't want your cookies, I don't want your money, I'll just go, bye \nJerry: You're rea
lly mean, I'm going to tell everyone, you're mean\nAmanda
INFO:torchtune.utils.logging:Time for inference: 47.79 sec total, 6.28 tokens/sec
INFO:torchtune.utils.logging:Bandwidth achieved: 61.40 GB/s
INFO:torchtune.utils.logging:Memory used: 22.97 GB
```


#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [X] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?

- Cast k,v,q to kv_cache dtype
- Clone token before feeding it to generate_next token (avoids torch.compile/CUDAGraph overwritten ssieu
- Remove size parameter in kvcache as its incompatible with torch.compile

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](../CONTRIBUTING.md) for some guidance on contributing.)

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](../tests/torchtune) for any new functionality
- [ ] update [docstrings](../docs/source) for any new or updated methods or classes
- [X] run unit tests via `pytest tests`
- [X] run recipe tests via `pytest tests -m integration_test`
- [X] manually run any new or modified recipes with sufficient proof of correctness
- [X] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [X] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
