### PR TITLE
[Fix] Qwen tokenizers mask trained EOS out of loss when max_seq_len is set (#2792)

### DIFF
--- a/torchtune/models/qwen2/_tokenizer.py
+++ b/torchtune/models/qwen2/_tokenizer.py
@@ -413,7 +413,7 @@ class Qwen2Tokenizer(ModelTokenizer):
             mask = truncate(
                 tokens=mask,
                 max_seq_len=self.max_seq_len,
-                eos_id=True if add_end_tokens else None,
+                eos_id=mask[-1] if add_end_tokens else None,
                 truncation_type=self.truncation_type,
             )
 

--- a/torchtune/models/qwen2_5/_tokenizer.py
+++ b/torchtune/models/qwen2_5/_tokenizer.py
@@ -198,7 +198,7 @@ class Qwen2_5Tokenizer(Qwen2Tokenizer):  # noqa: N801
             mask = truncate(
                 tokens=mask,
                 max_seq_len=self.max_seq_len,
-                eos_id=True if add_end_tokens else None,
+                eos_id=mask[-1] if add_end_tokens else None,
                 truncation_type=self.truncation_type,
             )
 


### PR DESCRIPTION
## Motivation

When `max_seq_len` is set, the Qwen2 / 2.5 / 3 tokenizers mask the trailing EOS token out of the loss, so the model is never trained to emit EOS and won't reliably stop generating (#2792).

## Root cause

In `tokenize_messages`, after appending EOS its mask is correctly set to `mask[-1]` (the final message's mask — `False`/trained for an assistant turn):

```python
if add_end_tokens:
    tokenized_messages.append(self.eos_id)
    mask.append(mask[-1])
```

But the subsequent `truncate(...)` of the mask hardcodes the forced last element to `True`:

```python
mask = truncate(
    tokens=mask,
    max_seq_len=self.max_seq_len,
    eos_id=True if add_end_tokens else None,   # forces mask[-1] = True even with no truncation
    truncation_type=self.truncation_type,
)
```

`truncate` sets the last element to `eos_id` whenever it is not `None`, so even when no truncation occurs the EOS mask flips `False -> True`, and `mask == True` maps to `CROSS_ENTROPY_IGNORE_IDX`. Net effect: with `max_seq_len` set, EOS is never a training target. Qwen3 subclasses Qwen2.5 and inherits the bug. (Llama3 intentionally always-masks EOS, so its identical line is correct there and is left unchanged.)

## Modifications

`torchtune/models/qwen2/_tokenizer.py` and `torchtune/models/qwen2_5/_tokenizer.py`: pass the EOS token's actual mask (`mask[-1]`) instead of hardcoded `True` to the mask `truncate(...)`, so the forced last element matches how the appended EOS was masked. `mask` is unmodified between the append and this call, and the token list already forces `self.eos_id` symmetrically.

## Duplicate-check

- Track A — the search API returned HTTP 422 for this token on this repo, so per fail-closed I enumerated all open PRs via the core API (`repos/pytorch/torchtune/pulls?state=open --paginate`) and grepped bodies for `2792` → no references. (The stalled PR #2512 edits the same Qwen EOS area but addresses a different root cause — whether EOS is appended at all — and does not reference #2792.)
- Track B — issue #2792 (state OPEN): the maintainer acknowledged it and labeled it a bug; no "opened a PR / taking this / working on this" claim.
