### PR TITLE
fix: respect Gemma tokenizer inference mode.

### DIFF
--- a/tests/torchtune/models/gemma/test_gemma_tokenizer.py
+++ b/tests/torchtune/models/gemma/test_gemma_tokenizer.py
@@ -81,3 +81,31 @@ class TestGemmaTokenizer:
         expected_mask = [True] * 75 + [False] * 124
         assert expected_tokens == tokens
         assert expected_mask == mask
+
+    def test_call_drops_eos_for_inference(self, tokenizer, expected_tokens):
+        messages = [
+            Message(
+                role="user",
+                content="Below is an instruction that describes a task. Write a response "
+                "that appropriately completes the request.\n\n### Instruction:\nGenerate "
+                "a realistic dating profile bio.\n\n### Response:\n",
+                masked=True,
+            ),
+            Message(
+                role="assistant",
+                content="I'm an outgoing and friendly person who loves spending time with "
+                "friends and family. I'm also a big-time foodie and love trying out new "
+                "restaurants and different cuisines. I'm a big fan of the arts and enjoy "
+                "going to museums and galleries. I'm looking for someone who shares my "
+                "interest in exploring new places, as well as someone who appreciates a "
+                "good conversation over coffee.",
+            ),
+        ]
+
+        train_sample = tokenizer({"messages": messages.copy()})
+        inference_sample = tokenizer({"messages": messages.copy()}, inference=True)
+
+        assert train_sample["tokens"] == expected_tokens
+        assert train_sample["mask"] == [True] * 75 + [False] * 125
+        assert inference_sample["tokens"] == expected_tokens[:-1]
+        assert inference_sample["mask"] == [True] * 75 + [False] * 124

--- a/tests/torchtune/models/mistral/test_mistral_tokenizer.py
+++ b/tests/torchtune/models/mistral/test_mistral_tokenizer.py
@@ -96,3 +96,14 @@ class TestMistralTokenizer:
         expected_mask = [True] * 75 + [False] * 124
         assert expected_tokens == tokens
         assert expected_mask == mask
+
+    def test_call_drops_eos_for_inference(self, messages, expected_tokens):
+        tokenizer = self.tokenizer(template=False)
+
+        train_sample = tokenizer({"messages": messages.copy()})
+        inference_sample = tokenizer({"messages": messages.copy()}, inference=True)
+
+        assert train_sample["tokens"] == expected_tokens
+        assert train_sample["mask"] == [True] * 75 + [False] * 125
+        assert inference_sample["tokens"] == expected_tokens[:-1]
+        assert inference_sample["mask"] == [True] * 75 + [False] * 124

--- a/torchtune/models/gemma/_tokenizer.py
+++ b/torchtune/models/gemma/_tokenizer.py
@@ -165,7 +165,7 @@ class GemmaTokenizer(ModelTokenizer, Transform):
                 and the "messages" field removed.
         """
         messages = sample.pop("messages")
-        tokens, mask = self.tokenize_messages(messages)
+        tokens, mask = self.tokenize_messages(messages, add_eos=not inference)
         sample["tokens"] = tokens
         sample["mask"] = mask
         return sample

--- a/torchtune/models/mistral/_tokenizer.py
+++ b/torchtune/models/mistral/_tokenizer.py
@@ -196,7 +196,7 @@ class MistralTokenizer(ModelTokenizer, Transform):
             inference (bool): Whether the template is being used for inference or not.
         """
         messages = sample.pop("messages")
-        tokens, mask = self.tokenize_messages(messages)
+        tokens, mask = self.tokenize_messages(messages, add_eos=not inference)
         sample["tokens"] = tokens
         sample["mask"] = mask
         return sample


### PR DESCRIPTION
#### Context
  What is the purpose of this PR? Is it to
  - [ ] add a new feature
  - [x] fix a bug
  - [x] update tests and/or documentation
  - [ ] other (please add here)

  Fixes #2478.

  `GemmaTokenizer.tokenize_messages(..., add_eos=False)` already supports omitting EOS, but
  `GemmaTokenizer.__call__(..., inference=True)` was not passing the inference mode through. As a result,
  the callable tokenizer path always appended EOS.

  #### Changelog
  What are the changes made in this PR?
  * Pass `add_eos=not inference` from `GemmaTokenizer.__call__`.
  * Add a regression test covering `inference=True`.

  #### Test plan
  Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of
  these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/
  torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

  - [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
  - [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new
  functionality
  - [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or
  updated methods or classes
  - [ ] run unit tests via `pytest tests`
  - [ ] run recipe tests via `pytest tests -m integration_test`
  - [ ] manually run any new or modified recipes with sufficient proof of correctness
  - [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval
  results, etc.)

  Commands run:
  * `git diff --check`
  * `python -m py_compile torchtune/models/gemma/_tokenizer.py tests/torchtune/models/gemma/
  test_gemma_tokenizer.py`

  I attempted to run:
  * `pytest tests/torchtune/models/gemma/test_gemma_tokenizer.py -q`

  but my local environment failed during torchtune test bootstrap because of a PyTorch/torchao compatibility
  issue around `torchao.quantization.NF4Tensor`.

  #### UX
  If your function changed a public API, please add a dummy example of what the user experience will look
  like when calling it.
  Here is a [docstring example](https://github.com/pytorch/torchtune/
  blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
  and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-
  llama3-models)

  - [x] I did not change any public API
  - [ ] I have added an example to docs or docstrings