### PR TITLE
Fix Mistral and Gemma end-token control

### DIFF
--- a/tests/torchtune/models/gemma/test_gemma_tokenizer.py
+++ b/tests/torchtune/models/gemma/test_gemma_tokenizer.py
@@ -55,7 +55,16 @@ class TestGemmaTokenizer:
         assert expected_tokens == tokens
         assert expected_mask == mask
 
-    def test_tokenize_messages_drop_eos(self, tokenizer, expected_tokens):
+    @pytest.mark.parametrize(
+        "add_start_tokens, add_end_tokens",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_tokenize_messages_special_token_control(
+        self, tokenizer, expected_tokens, add_start_tokens, add_end_tokens
+    ):
         messages = [
             Message(
                 role="user",
@@ -74,10 +83,17 @@ class TestGemmaTokenizer:
                 "good conversation over coffee.",
             ),
         ]
-        tokens, mask = tokenizer.tokenize_messages(messages, add_eos=False)
-        # Drop eos token.
-        expected_tokens = expected_tokens[:-1]
-        # On 1 less then with eos
-        expected_mask = [True] * 75 + [False] * 124
+        tokens, mask = tokenizer.tokenize_messages(
+            messages,
+            add_start_tokens=add_start_tokens,
+            add_end_tokens=add_end_tokens,
+        )
+        if not add_start_tokens:
+            expected_tokens = expected_tokens[1:]
+        if not add_end_tokens:
+            expected_tokens = expected_tokens[:-1]
+        expected_mask = [True] * (75 if add_start_tokens else 74) + [False] * (
+            125 if add_end_tokens else 124
+        )
         assert expected_tokens == tokens
         assert expected_mask == mask

--- a/tests/torchtune/models/gemma/test_gemma_tokenizer.py
+++ b/tests/torchtune/models/gemma/test_gemma_tokenizer.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import warnings
+
 import pytest
 from tests.common import ASSETS
 from torchtune.data import Message
@@ -83,11 +85,13 @@ class TestGemmaTokenizer:
                 "good conversation over coffee.",
             ),
         ]
-        tokens, mask = tokenizer.tokenize_messages(
-            messages,
-            add_start_tokens=add_start_tokens,
-            add_end_tokens=add_end_tokens,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            tokens, mask = tokenizer.tokenize_messages(
+                messages,
+                add_start_tokens=add_start_tokens,
+                add_end_tokens=add_end_tokens,
+            )
         if not add_start_tokens:
             expected_tokens = expected_tokens[1:]
         if not add_end_tokens:
@@ -98,12 +102,11 @@ class TestGemmaTokenizer:
         assert expected_tokens == tokens
         assert expected_mask == mask
 
-        if not add_end_tokens:
-            with pytest.deprecated_call():
-                legacy_tokens, legacy_mask = tokenizer.tokenize_messages(
-                    messages,
-                    add_start_tokens=add_start_tokens,
-                    add_eos=False,
-                )
-            assert legacy_tokens == tokens
-            assert legacy_mask == mask
+        with pytest.deprecated_call():
+            legacy_tokens, legacy_mask = tokenizer.tokenize_messages(
+                messages,
+                add_start_tokens=add_start_tokens,
+                add_eos=add_end_tokens,
+            )
+        assert legacy_tokens == tokens
+        assert legacy_mask == mask

--- a/tests/torchtune/models/gemma/test_gemma_tokenizer.py
+++ b/tests/torchtune/models/gemma/test_gemma_tokenizer.py
@@ -55,7 +55,16 @@ class TestGemmaTokenizer:
         assert expected_tokens == tokens
         assert expected_mask == mask
 
-    def test_tokenize_messages_drop_eos(self, tokenizer, expected_tokens):
+    @pytest.mark.parametrize(
+        "add_start_tokens, add_end_tokens",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_tokenize_messages_special_token_control(
+        self, tokenizer, expected_tokens, add_start_tokens, add_end_tokens
+    ):
         messages = [
             Message(
                 role="user",
@@ -74,10 +83,27 @@ class TestGemmaTokenizer:
                 "good conversation over coffee.",
             ),
         ]
-        tokens, mask = tokenizer.tokenize_messages(messages, add_eos=False)
-        # Drop eos token.
-        expected_tokens = expected_tokens[:-1]
-        # On 1 less then with eos
-        expected_mask = [True] * 75 + [False] * 124
+        tokens, mask = tokenizer.tokenize_messages(
+            messages,
+            add_start_tokens=add_start_tokens,
+            add_end_tokens=add_end_tokens,
+        )
+        if not add_start_tokens:
+            expected_tokens = expected_tokens[1:]
+        if not add_end_tokens:
+            expected_tokens = expected_tokens[:-1]
+        expected_mask = [True] * (75 if add_start_tokens else 74) + [False] * (
+            125 if add_end_tokens else 124
+        )
         assert expected_tokens == tokens
         assert expected_mask == mask
+
+        if not add_end_tokens:
+            with pytest.deprecated_call():
+                legacy_tokens, legacy_mask = tokenizer.tokenize_messages(
+                    messages,
+                    add_start_tokens=add_start_tokens,
+                    add_eos=False,
+                )
+            assert legacy_tokens == tokens
+            assert legacy_mask == mask

--- a/tests/torchtune/models/mistral/test_mistral_tokenizer.py
+++ b/tests/torchtune/models/mistral/test_mistral_tokenizer.py
@@ -86,13 +86,37 @@ class TestMistralTokenizer:
         assert expected_tokens == tokens
         assert expected_mask == mask
 
-    def test_tokenize_message_drop_eos(self, messages, expected_tokens):
+    @pytest.mark.parametrize(
+        "add_start_tokens, add_end_tokens",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_tokenize_messages_special_token_control(
+        self, messages, expected_tokens, add_start_tokens, add_end_tokens
+    ):
         tokenizer = self.tokenizer(template=False)
-        tokens, mask = tokenizer.tokenize_messages(messages, add_eos=False)
+        tokens, mask = tokenizer.tokenize_messages(
+            messages,
+            add_start_tokens=add_start_tokens,
+            add_end_tokens=add_end_tokens,
+        )
 
-        # Drop eos token.
-        expected_tokens = expected_tokens[:-1]
-        # On 1 less then with eos
-        expected_mask = [True] * 75 + [False] * 124
+        if not add_start_tokens:
+            expected_tokens = expected_tokens[1:]
+        if not add_end_tokens:
+            expected_tokens = expected_tokens[:-1]
+
+        expected_mask = [True] * (75 if add_start_tokens else 74) + [False] * (
+            125 if add_end_tokens else 124
+        )
         assert expected_tokens == tokens
         assert expected_mask == mask
+
+    def test_inference_drops_end_token(self, messages, expected_tokens):
+        tokenizer = self.tokenizer(template=False)
+        sample = tokenizer({"messages": messages}, inference=True)
+
+        assert sample["tokens"] == expected_tokens[:-1]
+        assert sample["mask"] == [True] * 75 + [False] * 124

--- a/tests/torchtune/models/mistral/test_mistral_tokenizer.py
+++ b/tests/torchtune/models/mistral/test_mistral_tokenizer.py
@@ -86,13 +86,47 @@ class TestMistralTokenizer:
         assert expected_tokens == tokens
         assert expected_mask == mask
 
-    def test_tokenize_message_drop_eos(self, messages, expected_tokens):
+    @pytest.mark.parametrize(
+        "add_start_tokens, add_end_tokens",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_tokenize_messages_special_token_control(
+        self, messages, expected_tokens, add_start_tokens, add_end_tokens
+    ):
         tokenizer = self.tokenizer(template=False)
-        tokens, mask = tokenizer.tokenize_messages(messages, add_eos=False)
+        tokens, mask = tokenizer.tokenize_messages(
+            messages,
+            add_start_tokens=add_start_tokens,
+            add_end_tokens=add_end_tokens,
+        )
 
-        # Drop eos token.
-        expected_tokens = expected_tokens[:-1]
-        # On 1 less then with eos
-        expected_mask = [True] * 75 + [False] * 124
+        if not add_start_tokens:
+            expected_tokens = expected_tokens[1:]
+        if not add_end_tokens:
+            expected_tokens = expected_tokens[:-1]
+
+        expected_mask = [True] * (75 if add_start_tokens else 74) + [False] * (
+            125 if add_end_tokens else 124
+        )
         assert expected_tokens == tokens
         assert expected_mask == mask
+
+        if not add_end_tokens:
+            with pytest.deprecated_call():
+                legacy_tokens, legacy_mask = tokenizer.tokenize_messages(
+                    messages,
+                    add_start_tokens=add_start_tokens,
+                    add_eos=False,
+                )
+            assert legacy_tokens == tokens
+            assert legacy_mask == mask
+
+    def test_inference_drops_end_token(self, messages, expected_tokens):
+        tokenizer = self.tokenizer(template=False)
+        sample = tokenizer({"messages": messages}, inference=True)
+
+        assert sample["tokens"] == expected_tokens[:-1]
+        assert sample["mask"] == [True] * 75 + [False] * 124

--- a/tests/torchtune/models/mistral/test_mistral_tokenizer.py
+++ b/tests/torchtune/models/mistral/test_mistral_tokenizer.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import warnings
+
 import pytest
 from tests.common import ASSETS
 from torchtune.data import Message
@@ -97,11 +99,13 @@ class TestMistralTokenizer:
         self, messages, expected_tokens, add_start_tokens, add_end_tokens
     ):
         tokenizer = self.tokenizer(template=False)
-        tokens, mask = tokenizer.tokenize_messages(
-            messages,
-            add_start_tokens=add_start_tokens,
-            add_end_tokens=add_end_tokens,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            tokens, mask = tokenizer.tokenize_messages(
+                messages,
+                add_start_tokens=add_start_tokens,
+                add_end_tokens=add_end_tokens,
+            )
 
         if not add_start_tokens:
             expected_tokens = expected_tokens[1:]
@@ -114,15 +118,14 @@ class TestMistralTokenizer:
         assert expected_tokens == tokens
         assert expected_mask == mask
 
-        if not add_end_tokens:
-            with pytest.deprecated_call():
-                legacy_tokens, legacy_mask = tokenizer.tokenize_messages(
-                    messages,
-                    add_start_tokens=add_start_tokens,
-                    add_eos=False,
-                )
-            assert legacy_tokens == tokens
-            assert legacy_mask == mask
+        with pytest.deprecated_call():
+            legacy_tokens, legacy_mask = tokenizer.tokenize_messages(
+                messages,
+                add_start_tokens=add_start_tokens,
+                add_eos=add_end_tokens,
+            )
+        assert legacy_tokens == tokens
+        assert legacy_mask == mask
 
     def test_inference_drops_end_token(self, messages, expected_tokens):
         tokenizer = self.tokenizer(template=False)

--- a/torchtune/models/gemma/_tokenizer.py
+++ b/torchtune/models/gemma/_tokenizer.py
@@ -104,7 +104,8 @@ class GemmaTokenizer(ModelTokenizer, Transform):
         self,
         messages: list[Message],
         *,
-        add_eos: bool = True,
+        add_start_tokens: bool = True,
+        add_end_tokens: bool = True,
     ) -> tuple[list[int], list[bool]]:
         r"""Tokenize a list of messages one at a time then concatenate them,
         returning a list of tokens and a list of masks.
@@ -131,7 +132,10 @@ class GemmaTokenizer(ModelTokenizer, Transform):
         Args:
             messages (list[Message]): A list of messages, each containing role, content,
                 and masked attributes.
-            add_eos (bool): Whether to append EOS after assistant message, default to True
+            add_start_tokens (bool): Whether to add BOS token to the beginning of the
+                first message. Default True.
+            add_end_tokens (bool): Whether to add EOS token to the end of the last
+                message. Default True.
 
         Returns:
             tuple[list[int], list[bool]]: The tokenized messages
@@ -144,8 +148,8 @@ class GemmaTokenizer(ModelTokenizer, Transform):
         return tokenize_messages_no_special_tokens(
             tokenizer=self,
             messages=templated_messages,
-            bos_id=self.bos_id,
-            eos_id=self.eos_id if add_eos else None,
+            bos_id=self.bos_id if add_start_tokens else None,
+            eos_id=self.eos_id if add_end_tokens else None,
             truncation_type=self.truncation_type,
         )
 
@@ -165,7 +169,7 @@ class GemmaTokenizer(ModelTokenizer, Transform):
                 and the "messages" field removed.
         """
         messages = sample.pop("messages")
-        tokens, mask = self.tokenize_messages(messages)
+        tokens, mask = self.tokenize_messages(messages, add_end_tokens=not inference)
         sample["tokens"] = tokens
         sample["mask"] = mask
         return sample

--- a/torchtune/models/gemma/_tokenizer.py
+++ b/torchtune/models/gemma/_tokenizer.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Any, Mapping, Optional
+from warnings import warn
 
 from torchtune.data import Message, PromptTemplate
 from torchtune.modules.transforms import Transform
@@ -104,7 +105,9 @@ class GemmaTokenizer(ModelTokenizer, Transform):
         self,
         messages: list[Message],
         *,
-        add_eos: bool = True,
+        add_start_tokens: bool = True,
+        add_end_tokens: bool = True,
+        add_eos: bool | None = None,
     ) -> tuple[list[int], list[bool]]:
         r"""Tokenize a list of messages one at a time then concatenate them,
         returning a list of tokens and a list of masks.
@@ -131,11 +134,25 @@ class GemmaTokenizer(ModelTokenizer, Transform):
         Args:
             messages (list[Message]): A list of messages, each containing role, content,
                 and masked attributes.
-            add_eos (bool): Whether to append EOS after assistant message, default to True
+            add_start_tokens (bool): Whether to add BOS token to the beginning of the
+                first message. Default True.
+            add_end_tokens (bool): Whether to add EOS token to the end of the last
+                message. Default True.
+            add_eos (bool | None): Deprecated compatibility alias for add_end_tokens.
+                When provided, it takes precedence.
 
         Returns:
             tuple[list[int], list[bool]]: The tokenized messages
         """
+        if add_eos is not None:
+            warn(
+                "add_eos is deprecated and will be removed in a future release. "
+                "Please use add_end_tokens instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            add_end_tokens = add_eos
+
         templated_messages = (
             self.prompt_template(messages)
             if self.prompt_template is not None
@@ -144,8 +161,8 @@ class GemmaTokenizer(ModelTokenizer, Transform):
         return tokenize_messages_no_special_tokens(
             tokenizer=self,
             messages=templated_messages,
-            bos_id=self.bos_id,
-            eos_id=self.eos_id if add_eos else None,
+            bos_id=self.bos_id if add_start_tokens else None,
+            eos_id=self.eos_id if add_end_tokens else None,
             truncation_type=self.truncation_type,
         )
 
@@ -165,7 +182,7 @@ class GemmaTokenizer(ModelTokenizer, Transform):
                 and the "messages" field removed.
         """
         messages = sample.pop("messages")
-        tokens, mask = self.tokenize_messages(messages)
+        tokens, mask = self.tokenize_messages(messages, add_end_tokens=not inference)
         sample["tokens"] = tokens
         sample["mask"] = mask
         return sample

--- a/torchtune/models/mistral/_tokenizer.py
+++ b/torchtune/models/mistral/_tokenizer.py
@@ -129,7 +129,8 @@ class MistralTokenizer(ModelTokenizer, Transform):
         self,
         messages: list[Message],
         *,
-        add_eos: bool = True,
+        add_start_tokens: bool = True,
+        add_end_tokens: bool = True,
     ) -> tuple[list[int], list[bool]]:
         r"""Tokenize a list of messages one at a time then concatenate them,
         returning a list of tokens and a list of masks.
@@ -161,7 +162,10 @@ class MistralTokenizer(ModelTokenizer, Transform):
         Args:
             messages (list[Message]): A list of messages, each containing role, content,
                 and masked attributes.
-            add_eos (bool): Whether to append EOS after assistant message, default to True
+            add_start_tokens (bool): Whether to add BOS token to the beginning of the
+                first message. Default True.
+            add_end_tokens (bool): Whether to add EOS token to the end of the last
+                message. Default True.
 
         Returns:
             tuple[list[int], list[bool]]: The tokenized messages
@@ -174,8 +178,8 @@ class MistralTokenizer(ModelTokenizer, Transform):
         return tokenize_messages_no_special_tokens(
             tokenizer=self,
             messages=templated_messages,
-            bos_id=self.bos_id,
-            eos_id=self.eos_id if add_eos else None,
+            bos_id=self.bos_id if add_start_tokens else None,
+            eos_id=self.eos_id if add_end_tokens else None,
             truncation_type=self.truncation_type,
         )
 
@@ -196,7 +200,7 @@ class MistralTokenizer(ModelTokenizer, Transform):
             inference (bool): Whether the template is being used for inference or not.
         """
         messages = sample.pop("messages")
-        tokens, mask = self.tokenize_messages(messages)
+        tokens, mask = self.tokenize_messages(messages, add_end_tokens=not inference)
         sample["tokens"] = tokens
         sample["mask"] = mask
         return sample

--- a/torchtune/models/mistral/_tokenizer.py
+++ b/torchtune/models/mistral/_tokenizer.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Any, Mapping, Optional
+from warnings import warn
 
 from torchtune.data import Message, PromptTemplate
 from torchtune.models.mistral._prompt_template import MistralChatTemplate
@@ -129,7 +130,9 @@ class MistralTokenizer(ModelTokenizer, Transform):
         self,
         messages: list[Message],
         *,
-        add_eos: bool = True,
+        add_start_tokens: bool = True,
+        add_end_tokens: bool = True,
+        add_eos: bool | None = None,
     ) -> tuple[list[int], list[bool]]:
         r"""Tokenize a list of messages one at a time then concatenate them,
         returning a list of tokens and a list of masks.
@@ -161,11 +164,25 @@ class MistralTokenizer(ModelTokenizer, Transform):
         Args:
             messages (list[Message]): A list of messages, each containing role, content,
                 and masked attributes.
-            add_eos (bool): Whether to append EOS after assistant message, default to True
+            add_start_tokens (bool): Whether to add BOS token to the beginning of the
+                first message. Default True.
+            add_end_tokens (bool): Whether to add EOS token to the end of the last
+                message. Default True.
+            add_eos (bool | None): Deprecated compatibility alias for add_end_tokens.
+                When provided, it takes precedence.
 
         Returns:
             tuple[list[int], list[bool]]: The tokenized messages
         """
+        if add_eos is not None:
+            warn(
+                "add_eos is deprecated and will be removed in a future release. "
+                "Please use add_end_tokens instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            add_end_tokens = add_eos
+
         templated_messages = (
             self.prompt_template(messages)
             if self.prompt_template is not None
@@ -174,8 +191,8 @@ class MistralTokenizer(ModelTokenizer, Transform):
         return tokenize_messages_no_special_tokens(
             tokenizer=self,
             messages=templated_messages,
-            bos_id=self.bos_id,
-            eos_id=self.eos_id if add_eos else None,
+            bos_id=self.bos_id if add_start_tokens else None,
+            eos_id=self.eos_id if add_end_tokens else None,
             truncation_type=self.truncation_type,
         )
 
@@ -196,7 +213,7 @@ class MistralTokenizer(ModelTokenizer, Transform):
             inference (bool): Whether the template is being used for inference or not.
         """
         messages = sample.pop("messages")
-        tokens, mask = self.tokenize_messages(messages)
+        tokens, mask = self.tokenize_messages(messages, add_end_tokens=not inference)
         sample["tokens"] = tokens
         sample["mask"] = mask
         return sample


### PR DESCRIPTION
## What

- align Mistral and Gemma tokenizers with the existing Llama 2 `add_start_tokens` / `add_end_tokens` API
- omit the final EOS token when either tokenizer is used for inference
- add focused coverage for BOS/EOS control and Mistral inference behavior

## Why

Mistral and Gemma still exposed the older `add_eos` switch and their transform path ignored the `inference` flag. That left generation inputs ending in EOS, unlike the corrected Llama tokenizer behavior, and provided no way to suppress the initial BOS token.

Fixes #2479.

## Impact & Compatibility Note

- **Compatibility note**: `add_end_tokens` is now the canonical keyword for Mistral and Gemma, aligning with the broader tokenizer API. The previous `add_eos` keyword remains supported as a compatibility alias, so existing direct callers do not need to migrate immediately.
- Default training behavior is unchanged.
- Inference transforms now omit the terminal EOS token so generation can continue, and callers can control boundary tokens consistently across tokenizers.

## Checks

- `ruff check` on all four changed files
- `ruff format --check` on all four changed files
- Python bytecode compilation on all four changed files