### PR TITLE
docs: fix broken 7B_full config link in recipe deep-dive

### DIFF
--- a/docs/source/deep_dives/recipe_deepdive.rst
+++ b/docs/source/deep_dives/recipe_deepdive.rst
@@ -63,7 +63,7 @@ In the following sections, we'll take a closer look at each of these components.
 For a complete working example, refer to the
 `full finetuning recipe <https://github.com/pytorch/torchtune/blob/main/recipes/full_finetune_distributed.py>`_
 in torchtune and the associated
-`config <https://github.com/pytorch/torchtune/blob/main/recipes/configs/7B_full.yaml>`_.
+`config <https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama2/7B_full.yaml>`_.
 
 .. TODO (SalmanMohammadi) ref to full finetune recipe doc
 


### PR DESCRIPTION
## Summary

The recipe deep-dive tutorial links to `recipes/configs/7B_full.yaml`, but the configs were reorganized into per-model-family directories, so that path 404s.

The surrounding text refers to the full-finetune recipe (`full_finetune_distributed.py`), which defaults to Llama2. The corresponding config now lives at `recipes/configs/llama2/7B_full.yaml`.

```diff
- .../blob/main/recipes/configs/7B_full.yaml
+ .../blob/main/recipes/configs/llama2/7B_full.yaml
```

Verified the target exists on `main`. Docs-only change.