### PR TITLE
Validate unsupported LoRA attention module names

### DIFF
--- a/tests/torchtune/modules/peft/test_utils.py
+++ b/tests/torchtune/modules/peft/test_utils.py
@@ -17,6 +17,7 @@ from torchtune.modules.peft import (
     DoRALinear,
     get_adapter_params,
     get_adapter_state_dict,
+    get_lora_module_names,
     get_merged_lora_ckpt,
     LoRALinear,
     set_trainable_params,
@@ -186,6 +187,39 @@ def lora_llama2_expected_base_model_keys():
         max_seq_len=MAX_SEQ_LEN,
     )
     return base_model.state_dict().keys()
+
+
+class TestGetLoraModuleNames:
+    def test_valid_lora_attn_modules(self):
+        assert get_lora_module_names(
+            lora_attn_modules=["q_proj", "v_proj"],
+            apply_lora_to_mlp=False,
+            apply_lora_to_output=False,
+        ) == ["q_proj", "v_proj"]
+
+    def test_unknown_lora_attn_module_raises(self):
+        with pytest.raises(ValueError, match="Unsupported LoRA attention modules"):
+            get_lora_module_names(
+                lora_attn_modules=["not_a_projection"],
+                apply_lora_to_mlp=False,
+                apply_lora_to_output=False,
+            )
+
+    def test_quote_corrupted_lora_attn_module_raises(self):
+        with pytest.raises(ValueError, match="'q_proj'"):
+            get_lora_module_names(
+                lora_attn_modules=["'q_proj'"],
+                apply_lora_to_mlp=False,
+                apply_lora_to_output=False,
+            )
+
+    def test_partially_invalid_lora_attn_modules_raises(self):
+        with pytest.raises(ValueError, match="typo"):
+            get_lora_module_names(
+                lora_attn_modules=["q_proj", "typo"],
+                apply_lora_to_mlp=False,
+                apply_lora_to_output=False,
+            )
 
 
 class TestPeftUtils:

--- a/torchtune/modules/peft/_utils.py
+++ b/torchtune/modules/peft/_utils.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import contextlib
-from typing import Any, Generator, Literal, Optional, Protocol, runtime_checkable, Union
+from typing import Any, Generator, Literal, Optional, Protocol, Union, get_args, runtime_checkable
 
 import torch
 import torch.distributed as dist
@@ -104,6 +104,14 @@ def get_lora_module_names(
     Returns:
         list[str]: list of module names in the model that have LoRA applied.
     """
+    supported_modules = set(get_args(LORA_ATTN_MODULES))
+    invalid_modules = set(lora_attn_modules) - supported_modules
+    if invalid_modules:
+        raise ValueError(
+            f"Unsupported LoRA attention modules: {sorted(invalid_modules)}. "
+            f"Expected one or more of {sorted(supported_modules)}."
+        )
+
     lora_module_keys = lora_attn_modules
     if apply_lora_to_mlp:
         lora_module_keys = lora_module_keys + ["w1", "w2", "w3"]


### PR DESCRIPTION
Raise a clear ValueError when lora_attn_modules includes unsupported projection names, preventing a configuration from silently constructing no matching LoRA adapters.

Add CPU-only coverage for valid, invalid, quote-corrupted, and partially invalid module lists.

#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
*

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
