### PR TITLE
[Draft] Add reference-free SimPO loss

### DIFF
--- a/recipes/configs/llama3_1/8B_lora_simpo_single_device.yaml
+++ b/recipes/configs/llama3_1/8B_lora_simpo_single_device.yaml
@@ -1,0 +1,93 @@
+# Config for single device LoRA SimPO alignment in lora_dpo_single_device.py
+# using a Llama 3.1 8B model
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download meta-llama/Meta-Llama-3.1-8B-Instruct --output-dir /tmp/Meta-Llama-3.1-8B-Instruct --ignore-patterns "original/consolidated.00.pth"
+#
+# To launch on a single device, run the following command from root:
+#   tune run lora_dpo_single_device --config llama3_1/8B_lora_simpo_single_device
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training
+# you can run:
+#   tune run lora_dpo_single_device --config llama3_1/8B_lora_simpo_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works only for training on single device.
+
+output_dir: /tmp/torchtune/llama3_1_8B/lora_simpo_single_device # /tmp may be deleted by your system. Change it to your preference.
+
+# Model Arguments
+model:
+  _component_: torchtune.models.llama3_1.lora_llama3_1_8b
+  lora_attn_modules: ['q_proj', 'v_proj', 'output_proj']
+  apply_lora_to_mlp: True
+  apply_lora_to_output: False
+  lora_rank: 8  # higher increases accuracy and memory
+  lora_alpha: 16  # usually alpha=2*rank
+  lora_dropout: 0.0
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.llama3.llama3_tokenizer
+  path: /tmp/Meta-Llama-3.1-8B-Instruct/original/tokenizer.model
+  max_seq_len: 1024 # higher increases memory
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
+  checkpoint_files: [
+    model-00001-of-00004.safetensors,
+    model-00002-of-00004.safetensors,
+    model-00003-of-00004.safetensors,
+    model-00004-of-00004.safetensors
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: LLAMA3
+resume_from_checkpoint: False
+save_adapter_weights_only: False
+
+# Dataset and Sampler
+dataset:
+  _component_: torchtune.datasets.stack_exchange_paired_dataset
+seed: null
+shuffle: True
+batch_size: 4
+
+# Optimizer and Scheduler
+optimizer:
+  _component_: torch.optim.AdamW
+  fused: True
+  weight_decay: 0.05
+  lr: 5e-4
+lr_scheduler:
+  _component_: torchtune.training.lr_schedulers.get_cosine_schedule_with_warmup
+  num_warmup_steps: 100
+
+loss:
+  _component_: torchtune.rlhf.loss.SimPOLoss
+  beta: 2.0
+  gamma_beta_ratio: 0.25
+
+# Training
+epochs: 1
+max_steps_per_epoch: 1000
+gradient_accumulation_steps: 8  # Use to increase effective batch size
+compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: True
+log_level: INFO  # DEBUG, WARN, etc.
+
+# Environment
+device: cuda
+dtype: bf16
+
+# Memory management
+enable_activation_checkpointing: True  # True reduces memory
+enable_activation_offloading: False  # True reduces memory

--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -776,13 +776,13 @@ class FullDPORecipeDistributed(FTRecipeInterface):
         chosen_log_probs = rlhf.get_batch_log_probs(
             all_logits[:len_chosen],
             concatenated_labels[:len_chosen],
-            return_average_logprobs=False,
+            return_average_logprobs=self._loss_fn.return_average_logprobs,
         )
 
         rejected_log_probs = rlhf.get_batch_log_probs(
             all_logits[len_chosen:],
             concatenated_labels[len_chosen:],
-            return_average_logprobs=False,
+            return_average_logprobs=self._loss_fn.return_average_logprobs,
         )
 
         chosen_logits = all_logits[:len_chosen]

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -612,7 +612,11 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         with self.activations_handling_ctx:
             all_logits = model(concatenated_input_ids)
 
-        all_log_probs = rlhf.get_batch_log_probs(all_logits, concatenated_labels)
+        all_log_probs = rlhf.get_batch_log_probs(
+            all_logits,
+            concatenated_labels,
+            return_average_logprobs=self._loss_fn.return_average_logprobs,
+        )
 
         chosen_log_probs = all_log_probs[:len_chosen]
         rejected_log_probs = all_log_probs[len_chosen:]

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -477,7 +477,11 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         with self.activations_handling_ctx:
             all_logits = model(concatenated_input_ids)
 
-        all_log_probs = rlhf.get_batch_log_probs(all_logits, concatenated_labels)
+        all_log_probs = rlhf.get_batch_log_probs(
+            all_logits,
+            concatenated_labels,
+            return_average_logprobs=self._loss_fn.return_average_logprobs,
+        )
 
         chosen_log_probs = all_log_probs[:len_chosen]
         rejected_log_probs = all_log_probs[len_chosen:]

--- a/tests/recipes/test_lora_dpo_single_device.py
+++ b/tests/recipes/test_lora_dpo_single_device.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import math
 import os
 import runpy
 import shutil
@@ -300,3 +301,58 @@ class TestLoRADPOSingleDeviceRecipe:
         llama3_model.load_state_dict(sd)
         merged_ckpt_out = llama3_model(inputs)
         torch.testing.assert_close(baseline_out, merged_ckpt_out, rtol=1e-5, atol=1e-5)
+
+    @pytest.mark.integration_test
+    @gpu_test(gpu_count=1)
+    def test_simpo_one_step_finite_loss(self, tmpdir, monkeypatch):
+        ckpt = "llama3_tune"
+        ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
+        ckpt_dir = ckpt_path.parent
+        log_file = gen_log_file_name(tmpdir)
+
+        write_hf_ckpt_config(ckpt_dir)
+
+        cmd = f"""
+        tune run lora_dpo_single_device \
+            --config llama3_1/8B_lora_simpo_single_device \
+            output_dir={tmpdir} \
+            model.lora_attn_modules=['q_proj','v_proj'] \
+            model.apply_lora_to_mlp=False \
+            checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
+            checkpointer.checkpoint_dir='{ckpt_dir}' \
+            checkpointer.checkpoint_files=[{ckpt_path}]\
+            checkpointer.output_dir={tmpdir} \
+            checkpointer.model_type=LLAMA3 \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
+            tokenizer.prompt_template=null \
+            metric_logger.filename={log_file} \
+            enable_activation_checkpointing=True \
+            enable_activation_offloading=False \
+        """.split()
+
+        model_config = MODEL_TEST_CONFIGS["llama3_lora"]
+        cmd = (
+            cmd
+            + [
+                "batch_size=1",
+                "dtype=fp32",
+                "dataset.train_on_input=False",
+                "seed=9",
+                "epochs=1",
+                "max_steps_per_epoch=1",
+                "optimizer.lr=2e-5",
+                "log_every_n_steps=1",
+                "gradient_accumulation_steps=1",
+                "clip_grad_norm=100",
+                "tokenizer.max_seq_len=512",
+            ]
+            + dummy_stack_exchange_dataset_config()
+            + model_config
+        )
+        monkeypatch.setattr(sys, "argv", cmd)
+        with pytest.raises(SystemExit, match=""):
+            runpy.run_path(TUNE_PATH, run_name="__main__")
+
+        loss_values = get_loss_values_from_metric_logger(log_file)
+        assert len(loss_values) >= 1
+        assert all(math.isfinite(loss) for loss in loss_values)

--- a/tests/torchtune/rlhf/loss/test_dpo_loss.py
+++ b/tests/torchtune/rlhf/loss/test_dpo_loss.py
@@ -7,7 +7,7 @@
 import pytest
 import torch
 from torchtune.rlhf._types import ChosenRejectedOutputs
-from torchtune.rlhf.loss import DPOLoss, RSOLoss
+from torchtune.rlhf.loss import DPOLoss, RSOLoss, SimPOLoss
 
 
 @pytest.fixture(autouse=True)
@@ -100,3 +100,99 @@ class TestDPOLosses:
         losses, *_ = rso_loss(*loss_inputs)
 
         torch.testing.assert_close(losses, expected_losses, atol=1e-4, rtol=1e-5)
+
+
+class TestSimPOLoss:
+    @pytest.fixture
+    def simpo_loss(self):
+        return SimPOLoss(
+            beta=2.0,
+            gamma_beta_ratio=0.25,
+        )
+
+    @pytest.fixture
+    def policy_inputs(self):
+        return ChosenRejectedOutputs(
+            torch.tensor([-0.5, -1.0, -2.0]),
+            torch.tensor([-1.0, -0.5, -2.5]),
+            torch.tensor(0),
+            torch.tensor(0),
+        )
+
+    def test_simpo_loss(self, simpo_loss, policy_inputs):
+        """
+        chosen - rejected - gamma_beta_ratio:
+            [-0.5 - (-1.0) - 0.25, -1.0 - (-0.5) - 0.25, -2.0 - (-2.5) - 0.25]
+            = [0.25, -0.75, 0.25]
+        scaled by beta=2.0: [0.5, -1.5, 0.5]
+        loss = -logsigmoid(scaled)
+        """
+        scaled_logits = torch.tensor([0.5, -1.5, 0.5])
+        expected_losses = -torch.nn.functional.logsigmoid(scaled_logits)
+        expected_chosen_rewards = 2.0 * policy_inputs.chosen_logps
+        expected_rejected_rewards = 2.0 * policy_inputs.rejected_logps
+
+        dummy_reference = ChosenRejectedOutputs(
+            torch.tensor([1.0, 2.0, 3.0]),
+            torch.tensor([4.0, 5.0, 6.0]),
+            torch.tensor(0),
+            torch.tensor(0),
+        )
+        losses, chosen_rewards, rejected_rewards = simpo_loss(
+            policy_inputs, dummy_reference
+        )
+
+        torch.testing.assert_close(losses, expected_losses, atol=1e-4, rtol=1e-5)
+        torch.testing.assert_close(
+            chosen_rewards, expected_chosen_rewards, atol=1e-4, rtol=1e-5
+        )
+        torch.testing.assert_close(
+            rejected_rewards, expected_rejected_rewards, atol=1e-4, rtol=1e-5
+        )
+
+    def test_all_none_reference_inputs(self, simpo_loss, policy_inputs):
+        none_reference = ChosenRejectedOutputs(None, None, None, None)
+        dummy_reference = ChosenRejectedOutputs(
+            torch.tensor([1.0, 2.0, 3.0]),
+            torch.tensor([4.0, 5.0, 6.0]),
+            torch.tensor(0),
+            torch.tensor(0),
+        )
+
+        losses_none, chosen_none, rejected_none = simpo_loss(
+            policy_inputs, none_reference
+        )
+        losses_dummy, chosen_dummy, rejected_dummy = simpo_loss(
+            policy_inputs, dummy_reference
+        )
+
+        torch.testing.assert_close(losses_none, losses_dummy, atol=1e-4, rtol=1e-5)
+        torch.testing.assert_close(chosen_none, chosen_dummy, atol=1e-4, rtol=1e-5)
+        torch.testing.assert_close(rejected_none, rejected_dummy, atol=1e-4, rtol=1e-5)
+
+    def test_properties(self):
+        simpo_loss = SimPOLoss()
+        assert simpo_loss.is_reference_free is True
+        assert simpo_loss.return_average_logprobs is True
+        assert DPOLoss().is_reference_free is False
+        assert DPOLoss().return_average_logprobs is False
+        assert RSOLoss().is_reference_free is False
+        assert RSOLoss().return_average_logprobs is False
+
+    def test_finite_gradients(self, simpo_loss):
+        policy_inputs = ChosenRejectedOutputs(
+            torch.tensor([-0.5, -1.0, -2.0], requires_grad=True),
+            torch.tensor([-1.0, -0.5, -2.5], requires_grad=True),
+            torch.tensor(0),
+            torch.tensor(0),
+        )
+        none_reference = ChosenRejectedOutputs(None, None, None, None)
+
+        losses, *_ = simpo_loss(policy_inputs, none_reference)
+        assert torch.isfinite(losses).all()
+
+        losses.mean().backward()
+        assert policy_inputs.chosen_logps.grad is not None
+        assert policy_inputs.rejected_logps.grad is not None
+        assert torch.isfinite(policy_inputs.chosen_logps.grad).all()
+        assert torch.isfinite(policy_inputs.rejected_logps.grad).all()

--- a/tests/torchtune/rlhf/test_sequence_processing.py
+++ b/tests/torchtune/rlhf/test_sequence_processing.py
@@ -5,7 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+import torch.nn.functional as F
 from torchtune import rlhf
+from torchtune.data import CROSS_ENTROPY_IGNORE_IDX
 
 
 class TestTruncateSequenceAtFirstStopToken:
@@ -59,3 +61,34 @@ class TestTruncateSequenceAtFirstStopToken:
 
         assert expected_eos_mask.eq(eos_mask).all()
         assert expected_sequences.eq(truncated_sequences).all()
+
+
+class TestGetBatchLogProbs:
+    def test_sum_versus_average_unequal_lengths(self):
+        torch.manual_seed(0)
+        logits = torch.randn(2, 4, 5)
+        labels = torch.tensor(
+            [
+                [0, 1, CROSS_ENTROPY_IGNORE_IDX, CROSS_ENTROPY_IGNORE_IDX],
+                [0, 2, 3, 4],
+            ]
+        )
+
+        summed = rlhf.get_batch_log_probs(logits, labels, return_average_logprobs=False)
+        averaged = rlhf.get_batch_log_probs(logits, labels, return_average_logprobs=True)
+
+        shifted_labels = labels[:, 1:].clone()
+        shifted_logits = logits[:, :-1, :]
+        loss_mask = shifted_labels != CROSS_ENTROPY_IGNORE_IDX
+        gather_labels = shifted_labels.masked_fill(~loss_mask, 0)
+        per_token_log_probs = torch.gather(
+            F.log_softmax(shifted_logits, dim=-1),
+            2,
+            gather_labels.unsqueeze(-1),
+        ).squeeze(-1)
+        expected_sum = (per_token_log_probs * loss_mask).sum(-1)
+        expected_mean = expected_sum / loss_mask.sum(-1)
+
+        torch.testing.assert_close(summed, expected_sum, atol=1e-4, rtol=1e-5)
+        torch.testing.assert_close(averaged, expected_mean, atol=1e-4, rtol=1e-5)
+        assert not torch.allclose(summed, averaged)

--- a/torchtune/_recipe_registry.py
+++ b/torchtune/_recipe_registry.py
@@ -379,6 +379,10 @@ _ALL_RECIPES = [
                 name="llama3_1/8B_lora_dpo_single_device",
                 file_path="llama3_1/8B_lora_dpo_single_device.yaml",
             ),
+            Config(
+                name="llama3_1/8B_lora_simpo_single_device",
+                file_path="llama3_1/8B_lora_simpo_single_device.yaml",
+            ),
         ],
         supports_distributed=False,
     ),

--- a/torchtune/rlhf/loss/__init__.py
+++ b/torchtune/rlhf/loss/__init__.py
@@ -5,11 +5,12 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from .dpo import DPOLoss, RSOLoss
+from .dpo import DPOLoss, RSOLoss, SimPOLoss
 from .ppo import PPOLoss
 
 __all__ = [
     "DPOLoss",
     "RSOLoss",
+    "SimPOLoss",
     "PPOLoss",
 ]

--- a/torchtune/rlhf/loss/dpo.py
+++ b/torchtune/rlhf/loss/dpo.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import dataclass
+from typing import Optional, Tuple, TypeVar
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -17,6 +20,11 @@ T = TypeVar("T", bound=dataclass)
 class PreferenceLoss(nn.Module):
     @property
     def is_reference_free(self) -> bool:
+        return False
+
+    @property
+    def return_average_logprobs(self) -> bool:
+        """If True, sequence log-probs are masked means; if False, masked sums."""
         return False
 
     def forward(
@@ -177,5 +185,66 @@ class RSOLoss(PreferenceLoss):
             self.gamma
             * (policy_inputs.rejected_logps - reference_inputs.rejected_logps).detach()
         )
+
+        return losses, chosen_rewards, rejected_rewards
+
+
+class SimPOLoss(PreferenceLoss):
+    """
+    Simple Preference Optimization (SimPO) Loss module: https://arxiv.org/abs/2405.14734
+
+    SimPO uses a reference-free implicit reward equal to the average log probability of
+    response tokens under the policy, and applies a target reward margin in the
+    Bradley-Terry objective. Policy ``chosen_logps`` and ``rejected_logps`` must be
+    masked averages over response tokens, not sequence sums.
+
+    Args:
+        beta (float): Scaling factor for the implicit reward. Default is 2.0.
+        gamma_beta_ratio (float): Target reward margin divided by beta (γ/β). Default is 0.25.
+    """
+
+    def __init__(
+        self,
+        beta: float = 2.0,
+        gamma_beta_ratio: float = 0.25,
+    ):
+        super().__init__()
+        self.beta = beta
+        self.gamma_beta_ratio = gamma_beta_ratio
+
+    @property
+    def is_reference_free(self) -> bool:
+        return True
+
+    @property
+    def return_average_logprobs(self) -> bool:
+        return True
+
+    def forward(
+        self,
+        policy_inputs: ChosenRejectedOutputs,
+        _reference_inputs: ChosenRejectedOutputs,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Compute the SimPO loss for a batch of policy model log probabilities.
+
+        Args:
+            policy_inputs (ChosenRejectedOutputs): Policy log-probs and logits required for the calculation.
+                ``chosen_logps`` and ``rejected_logps`` must be masked averages over response tokens.
+            _reference_inputs (ChosenRejectedOutputs): Unused. Present to match the PreferenceLoss signature.
+
+        Returns:
+            tuple[torch.Tensor, torch.Tensor, torch.Tensor]: A tuple of three tensors:
+                - losses: The SimPO loss for each example in the batch.
+                - chosen_rewards: Rewards for the chosen responses.
+                - rejected_rewards: Rewards for the rejected responses.
+        """
+        pi_logratios = policy_inputs.chosen_logps - policy_inputs.rejected_logps
+        logits = pi_logratios - self.gamma_beta_ratio
+
+        losses = -F.logsigmoid(self.beta * logits)
+
+        chosen_rewards = (self.beta * policy_inputs.chosen_logps).detach()
+        rejected_rewards = (self.beta * policy_inputs.rejected_logps).detach()
 
         return losses, chosen_rewards, rejected_rewards


### PR DESCRIPTION
## Draft - design feedback requested

This PR adds native support for SimPO (Simple Preference Optimization) using
Torchtune's existing paired-preference DPO pipeline.

I am opening this as a draft because SimPO requires response-token-average log
probabilities, while existing DPO and RSO losses consume summed response log
probabilities. The PR preserves existing DPO/RSO behavior and requests review
of the loss-level aggregation contract.

Feedback is especially welcome on:

1. Whether `PreferenceLoss.return_average_logprobs` is the preferred interface
   for losses that require averaged rather than summed sequence log
   probabilities.
2. Whether SimPO should live in the stable `torchtune.rlhf.loss` API or under
   `torchtune.dev`.
3. Whether the dedicated single-device LoRA SimPO config belongs in this PR.

## Summary

- Add reference-free `SimPOLoss(beta=2.0, gamma_beta_ratio=0.25)`.
- Add a backward-compatible `PreferenceLoss.return_average_logprobs` property.
- Preserve summed log-probability behavior for DPO and RSO.
- Use masked average response-token log probabilities for SimPO.
- Add `llama3_1/8B_lora_simpo_single_device`.
- Add unit tests for the SimPO objective, reference-free inputs, gradients,
  and summed-versus-averaged log-probability aggregation.
- Add a one-step GPU integration test using the registered SimPO config.

## SimPO compatibility

SimPO is a reference-free paired-preference objective that uses the average
log probability over unmasked response tokens. Existing Torchtune DPO recipes
currently provide summed sequence log probabilities to preference losses.

Torchtune already supports the required masked averaging through:

```python
get_batch_log_probs(..., return_average_logprobs=True)
```

This PR exposes that selection through the loss contract while retaining
existing summed-log-probability behavior for DPO and RSO.

## Scope

- Reuses existing paired preference datasets and collator.
- Does not change DPO or RSO loss behavior.
- Does not add SimPO's optional SFT term, hinge mode, or label smoothing.
- Does not change full-DPO reference-model setup; SimPO skips the reference
  forward through the existing reference-free path.
- Adds no benchmark, convergence, memory, or performance claims.

## Testing

```text
python3 -m pytest \
  tests/torchtune/rlhf/loss/test_dpo_loss.py \
  tests/torchtune/rlhf/test_sequence_processing.py \
  -vv
# 8 passed

python3 -m pytest \
  tests/recipes/test_lora_dpo_single_device.py \
  --collect-only -q
# SimPO integration test collected with integration_test and 1-GPU markers

git diff --check HEAD
```

The new GPU/S3-backed integration test was not run locally because a GPU and
the required test checkpoint artifacts are unavailable. It is collected with
the existing integration and one-GPU markers for the applicable upstream CI
workflow.

## References

- SimPO paper: [arXiv:2405.14734](https://arxiv.org/abs/2405.14734)
- Official implementation: [princeton-nlp/SimPO](https://github.com/princeton-nlp/SimPO)