### PR TITLE
fix: clarify DistributedCheckpointer recipe configuration

### DIFF
--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -289,6 +289,12 @@ can take significant time.
 To enable asynchronous checkpointing in your training config, you need to set the ``enable_async_checkpointing``
 flag to ``True``. The DistributedCheckpointer will be automatically used when this flag is enabled.
 
+.. note::
+
+    Do not configure ``DistributedCheckpointer`` directly as the recipe's ``checkpointer``. It is used internally
+    for intermediate checkpoints and cannot load the base model checkpoint or write the final model-format checkpoint.
+    Configure a model checkpointer, such as ``FullModelHFCheckpointer``, and set ``enable_async_checkpointing: True``.
+
 .. code-block:: yaml
 
     checkpointer:

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -263,7 +263,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                 )
         elif (
             self._enable_activation_checkpointing
-            and cfg.checkpointer.model_type != "LLAMA3_VISION"
+            and cfg.checkpointer.get("model_type") != "LLAMA3_VISION"
         ):
             utils.log_rank_zero(
                 self._logger,

--- a/tests/torchtune/training/checkpointing/test_checkpoint_client.py
+++ b/tests/torchtune/training/checkpointing/test_checkpoint_client.py
@@ -1,0 +1,32 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+from omegaconf import OmegaConf
+
+from torchtune.training.checkpointing._checkpoint_client import CheckpointClient
+
+
+def test_distributed_checkpointer_cannot_be_configured_as_base_checkpointer(
+    tmp_path,
+):
+    cfg = OmegaConf.create(
+        {
+            "device": "cpu",
+            "checkpointer": {
+                "_component_": "torchtune.training.DistributedCheckpointer",
+                "checkpoint_dir": str(tmp_path / "checkpoint"),
+                "output_dir": str(tmp_path / "output"),
+                "model_type": "LLAMA2",
+            },
+        }
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="DistributedCheckpointer.*base checkpointer",
+    ):
+        CheckpointClient(cfg)

--- a/torchtune/training/checkpointing/_checkpoint_client.py
+++ b/torchtune/training/checkpointing/_checkpoint_client.py
@@ -97,6 +97,30 @@ class CheckpointClient:
         _, self._rank = utils.get_world_size_and_rank()
         self._is_rank_zero = self._rank == 0
 
+        self._validate_checkpointer_config()
+
+    def _validate_checkpointer_config(self) -> None:
+        """Validate that the configured checkpointer can load a base checkpoint."""
+        if self._checkpointer is not None:
+            return
+
+        checkpointer_config = self._cfg.get("checkpointer")
+        if checkpointer_config is None:
+            return
+
+        component = checkpointer_config.get("_component_")
+        if component in (
+            "torchtune.training.DistributedCheckpointer",
+            "torchtune.training.checkpointing.DistributedCheckpointer",
+        ):
+            raise ValueError(
+                "DistributedCheckpointer is used internally for asynchronous "
+                "intermediate checkpoints and cannot be configured as the base "
+                "checkpointer. Configure a model checkpointer, such as "
+                "FullModelHFCheckpointer, and set enable_async_checkpointing=True "
+                "to enable distributed checkpointing."
+            )
+
     def _get_checkpointer(self):
         """
         Builds and returns the user configured Checkpointer.


### PR DESCRIPTION
Fixes #2907

## Context

`DistributedCheckpointer` is selected internally for asynchronous intermediate checkpoints. Configuring it as the recipe's primary `checkpointer` currently produces confusing errors: `model_type` is rejected by its constructor, and removing it exposes a missing-key error in the distributed finetuning recipe.

## Changes

- Validate the configured checkpointer early and provide an actionable error when `DistributedCheckpointer` is used as the base checkpointer.
- Read the optional `model_type` config defensively in `full_finetune_distributed`.
- Document the supported configuration: use a model checkpointer for the base/final checkpoint and enable `enable_async_checkpointing` to use DCP for intermediate checkpoints.
- Add a regression test for the invalid configuration.

## Validation

- `pre-commit run --files torchtune/training/checkpointing/_checkpoint_client.py recipes/full_finetune_distributed.py tests/torchtune/training/checkpointing/test_checkpoint_client.py`
- `python -m compileall -q recipes/full_finetune_distributed.py torchtune/training/checkpointing/_checkpoint_client.py tests/torchtune/training/checkpointing/test_checkpoint_client.py`
- The targeted pytest suite could not run locally because this environment does not have `torch`/`torchao` installed; CI should provide the project test dependencies.