### PR TITLE
fix(eval): support configurable and harness-requested generation budget in eleuther_eval

### DIFF
--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -297,6 +297,8 @@ class _LLMEvalWrapper(HFLM):
         batch_size (int): The batch size per GPU to use.
         dtype (torch.dtype): dtype for the model caches during generation.
         enable_kv_cache (bool): Whether to enable KV cache for generation.
+        max_gen_toks (int): Default maximum number of tokens to generate if not specified
+            by the evaluation task. Default is 256.
     """
 
     def __init__(
@@ -309,6 +311,7 @@ class _LLMEvalWrapper(HFLM):
         batch_size: int = 8,
         dtype: torch.dtype = torch.float32,
         enable_kv_cache: bool = True,
+        max_gen_toks: int = 256,
     ):
         # TODO (@joecummings): Remove this init function so we don't load in extraneous stuff
         super().__init__(pretrained="gpt2", device=str(device))
@@ -318,6 +321,7 @@ class _LLMEvalWrapper(HFLM):
         self._batch_size = batch_size
         self._dtype = dtype
         self._enable_kv_cache = enable_kv_cache
+        self._max_gen_toks = max_gen_toks
         # Set device explicitely here since HPU is not included in
         # `device_list` in `HFLM` class
         self._device = torch.device(device)
@@ -336,7 +340,7 @@ class _LLMEvalWrapper(HFLM):
 
     @property
     def max_gen_toks(self):
-        return 256
+        return self._max_gen_toks
 
     @property
     def batch_size(self):
@@ -423,6 +427,11 @@ class _LLMEvalWrapper(HFLM):
             (0, 0, 0, self._batch_size - bsz),
             value=self._tokenizer.eos_id,  # pad with one of the tokenizer's stop tokens so generation can stop early
         )
+        max_generated_tokens = generation_kwargs.get(
+            "max_gen_toks",
+            generation_kwargs.get("max_new_tokens", self.max_gen_toks),
+        )
+
         with local_kv_cache(
             self.model,
             batch_size=self.batch_size,
@@ -433,7 +442,7 @@ class _LLMEvalWrapper(HFLM):
             toks, _ = generate(
                 self.model,
                 maybe_padded_context,
-                max_generated_tokens=self.max_gen_toks,
+                max_generated_tokens=max_generated_tokens,
                 temperature=temperature,
                 top_k=None,
                 pad_id=self._tokenizer.pad_id,
@@ -537,6 +546,7 @@ class EleutherEvalRecipe(EvalRecipeInterface):
         model_transform = config.instantiate(cfg.tokenizer)
 
         # Finally, we setup the actual EvalWrapper class
+        extra_kwargs = {}
         if isinstance(model, DeepFusionModel):
             eleuther_model_wrapper = _VLMEvalWrapper
             if not self.enable_kv_cache:
@@ -546,6 +556,8 @@ class EleutherEvalRecipe(EvalRecipeInterface):
                 )
         elif isinstance(model, TransformerDecoder):
             eleuther_model_wrapper = _LLMEvalWrapper
+            if "max_gen_toks" in cfg:
+                extra_kwargs["max_gen_toks"] = cfg.max_gen_toks
         self.eleuther_model_wrapper = eleuther_model_wrapper(
             model,
             model_transform,
@@ -554,6 +566,7 @@ class EleutherEvalRecipe(EvalRecipeInterface):
             batch_size=self.batch_size,
             dtype=self.dtype,
             enable_kv_cache=self.enable_kv_cache,
+            **extra_kwargs,
         )
 
     def evaluate(self) -> None:

--- a/tests/recipes/test_eleuther_eval_unit.py
+++ b/tests/recipes/test_eleuther_eval_unit.py
@@ -1,0 +1,192 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+
+@pytest.fixture(scope="module")
+def eleuther_eval_module():
+    """Load eleuther_eval recipe module with mocked lm_eval dependencies."""
+    mock_lm_eval = MagicMock()
+
+    class MockHFLM:
+        def __init__(self, pretrained=None, device=None):
+            pass
+
+    class MockHFMultimodalLM:
+        pass
+
+    mock_lm_eval.models.huggingface.HFLM = MockHFLM
+    mock_lm_eval.models.hf_vlms.HFMultimodalLM = MockHFMultimodalLM
+
+    saved_modules = {}
+    mock_keys = [
+        "lm_eval",
+        "lm_eval.evaluator",
+        "lm_eval.models",
+        "lm_eval.models.hf_vlms",
+        "lm_eval.models.huggingface",
+        "lm_eval.tasks",
+        "lm_eval.utils",
+    ]
+    for k in mock_keys:
+        saved_modules[k] = sys.modules.get(k)
+        if k == "lm_eval":
+            sys.modules[k] = mock_lm_eval
+        elif k == "lm_eval.models.huggingface":
+            sys.modules[k] = mock_lm_eval.models.huggingface
+        elif k == "lm_eval.models.hf_vlms":
+            sys.modules[k] = mock_lm_eval.models.hf_vlms
+        else:
+            sys.modules[k] = getattr(mock_lm_eval, k.split(".")[-1], MagicMock())
+
+    recipe_path = (
+        Path(__file__).parent.parent.parent / "recipes" / "eleuther_eval.py"
+    ).resolve()
+    spec = importlib.util.spec_from_file_location("eleuther_eval", recipe_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    yield module
+
+    for k, v in saved_modules.items():
+        if v is None:
+            sys.modules.pop(k, None)
+        else:
+            sys.modules[k] = v
+
+
+class TestEleutherEvalGenerationBudget:
+    """Unit tests for configurable generation budget and harness override resolution."""
+
+    @pytest.fixture
+    def mock_model(self):
+        model = MagicMock()
+        model.dtype = torch.float32
+        return model
+
+    @pytest.fixture
+    def mock_tokenizer(self):
+        tokenizer = MagicMock()
+        tokenizer.eos_id = 0
+        tokenizer.pad_id = 0
+        tokenizer.stop_tokens = [0]
+        return tokenizer
+
+    def test_default_max_gen_toks(
+        self, eleuther_eval_module, mock_model, mock_tokenizer
+    ):
+        wrapper = eleuther_eval_module._LLMEvalWrapper(
+            mock_model,
+            mock_tokenizer,
+            device="cpu",
+            max_seq_length=2048,
+            batch_size=2,
+        )
+        assert wrapper.max_gen_toks == 256
+
+    def test_custom_max_gen_toks(
+        self, eleuther_eval_module, mock_model, mock_tokenizer
+    ):
+        wrapper = eleuther_eval_module._LLMEvalWrapper(
+            mock_model,
+            mock_tokenizer,
+            device="cpu",
+            max_seq_length=2048,
+            batch_size=2,
+            max_gen_toks=512,
+        )
+        assert wrapper.max_gen_toks == 512
+
+    def test_model_generate_uses_default_when_no_harness_kwargs(
+        self, eleuther_eval_module, mock_model, mock_tokenizer
+    ):
+        wrapper = eleuther_eval_module._LLMEvalWrapper(
+            mock_model,
+            mock_tokenizer,
+            device="cpu",
+            max_seq_length=2048,
+            batch_size=2,
+            max_gen_toks=512,
+        )
+        context = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.long)
+
+        with (
+            patch.object(eleuther_eval_module, "local_kv_cache"),
+            patch.object(eleuther_eval_module, "generate") as mock_generate,
+        ):
+            mock_generate.return_value = (torch.zeros((2, 10)), None)
+            wrapper._model_generate(context)
+            assert mock_generate.call_args.kwargs["max_generated_tokens"] == 512
+
+    def test_model_generate_overridden_by_max_gen_toks(
+        self, eleuther_eval_module, mock_model, mock_tokenizer
+    ):
+        wrapper = eleuther_eval_module._LLMEvalWrapper(
+            mock_model,
+            mock_tokenizer,
+            device="cpu",
+            max_seq_length=2048,
+            batch_size=2,
+            max_gen_toks=256,
+        )
+        context = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.long)
+
+        with (
+            patch.object(eleuther_eval_module, "local_kv_cache"),
+            patch.object(eleuther_eval_module, "generate") as mock_generate,
+        ):
+            mock_generate.return_value = (torch.zeros((2, 10)), None)
+            wrapper._model_generate(context, max_gen_toks=64)
+            assert mock_generate.call_args.kwargs["max_generated_tokens"] == 64
+
+    def test_model_generate_overridden_by_max_new_tokens(
+        self, eleuther_eval_module, mock_model, mock_tokenizer
+    ):
+        wrapper = eleuther_eval_module._LLMEvalWrapper(
+            mock_model,
+            mock_tokenizer,
+            device="cpu",
+            max_seq_length=2048,
+            batch_size=2,
+            max_gen_toks=256,
+        )
+        context = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.long)
+
+        with (
+            patch.object(eleuther_eval_module, "local_kv_cache"),
+            patch.object(eleuther_eval_module, "generate") as mock_generate,
+        ):
+            mock_generate.return_value = (torch.zeros((2, 10)), None)
+            wrapper._model_generate(context, max_new_tokens=128)
+            assert mock_generate.call_args.kwargs["max_generated_tokens"] == 128
+
+    def test_model_generate_precedence_max_gen_toks_over_max_new_tokens(
+        self, eleuther_eval_module, mock_model, mock_tokenizer
+    ):
+        wrapper = eleuther_eval_module._LLMEvalWrapper(
+            mock_model,
+            mock_tokenizer,
+            device="cpu",
+            max_seq_length=2048,
+            batch_size=2,
+            max_gen_toks=256,
+        )
+        context = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.long)
+
+        with (
+            patch.object(eleuther_eval_module, "local_kv_cache"),
+            patch.object(eleuther_eval_module, "generate") as mock_generate,
+        ):
+            mock_generate.return_value = (torch.zeros((2, 10)), None)
+            wrapper._model_generate(context, max_gen_toks=32, max_new_tokens=64)
+            assert mock_generate.call_args.kwargs["max_generated_tokens"] == 32


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] fix a bug
- [x] update tests and/or documentation

Fixes #2990.

#### Changelog
What are the changes made in this PR?
* Support configurable generation budget (max_gen_toks) in _LLMEvalWrapper.__init__ (defaulting to 256).
* Support per-task generation budget resolution in _LLMEvalWrapper._model_generate by extracting max_gen_toks or max_new_tokens from generation_kwargs passed by lm-evaluation-harness, falling back to self.max_gen_toks.
* Forward max_gen_toks from cfg to _LLMEvalWrapper in EleutherEvalRecipe.setup when configured.
* Update _LLMEvalWrapper docstring to document max_gen_toks.
* Add comprehensive unit test suite in tests/recipes/test_eleuther_eval_unit.py covering default budget, custom budget, harness overrides (max_gen_toks and max_new_tokens), and precedence.

#### Test plan
- [x] run pre-commit hooks and linters (ruff check and ruff format)
- [x] add unit tests for any new functionality (tests/recipes/test_eleuther_eval_unit.py)
- [x] update docstrings for any new or updated methods or classes
- [x] run unit tests via pytest tests/recipes/test_eleuther_eval_unit.py -v (6/6 passing)

Test execution output:
```bash
pytest tests/recipes/test_eleuther_eval_unit.py -v
# 6 passed in 0.03s

ruff check recipes/eleuther_eval.py tests/recipes/test_eleuther_eval_unit.py
# All checks passed!

ruff format --check recipes/eleuther_eval.py tests/recipes/test_eleuther_eval_unit.py
# 2 files already formatted
```

#### UX
- [x] I did not change any public API
